### PR TITLE
refactor: rename BoardIntoIterator to BoardIterator and remove IntoIterator implementation

### DIFF
--- a/engine/src/board/mod.rs
+++ b/engine/src/board/mod.rs
@@ -231,26 +231,21 @@ impl Board {
     pub fn get_population(&self) -> usize {
         self.population
     }
-}
 
-impl<'a> IntoIterator for &'a Board {
-    type Item = CellDesc;
-    type IntoIter = BoardIntoIterator<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        BoardIntoIterator {
-            board: &self,
+    pub fn iter(&self) -> BoardIterator {
+        BoardIterator {
+            board: self,
             cell_iter: Box::new(self.cells.get_iter())
         }
     }
 }
 
-pub struct BoardIntoIterator<'a> {
+pub struct BoardIterator<'a> {
     board: &'a Board,
     cell_iter: Box<Iterator<Item=CellIterType> + 'a>
 }
 
-impl<'a> Iterator for BoardIntoIterator<'a> {
+impl<'a> Iterator for BoardIterator<'a> {
     type Item = CellDesc;
 
     fn next(&mut self) -> Option<CellDesc> {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -70,7 +70,7 @@ impl Engine {
         let mut new_board = Self::new_board(board_type,
                                             self.board.get_cols(), self.board.get_rows());
 
-        for CellDesc { coord, gen, is_alive, .. } in self.board.into_iter() {
+        for CellDesc { coord, gen, is_alive, .. } in self.board.iter() {
             if is_alive {
                 new_board.born_at_gen(coord.col, coord.row, gen);
             }
@@ -136,7 +136,7 @@ impl Engine {
 
         let mut density_table: HashMap<isize, MinMax> = HashMap::new();
 
-        for CellDesc { coord, gen, is_alive, .. } in self.board.into_iter() {
+        for CellDesc { coord, gen, is_alive, .. } in self.board.iter() {
 
             let col = coord.col;
             let row = coord.row;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,5 +1,5 @@
 mod board;
 mod engine;
 
-pub use board::{Board, BoardIntoIterator, CellDesc};
+pub use board::{Board, BoardIterator, CellDesc};
 pub use engine::Engine;

--- a/ui/src/windows/board.rs
+++ b/ui/src/windows/board.rs
@@ -66,7 +66,7 @@ impl WindowBase for GameBoard {
             {
                 let engine = self.engine.borrow();
 
-                for CellDesc { coord, gen, is_alive, .. } in engine.get_board().into_iter() {
+                for CellDesc { coord, gen, is_alive, .. } in engine.get_board().iter() {
                     if is_alive {
                         let (x, y) = self.to_screen(coord.col, coord.row);
                         rectangle(GameBoard::get_color(gen), [x, y,


### PR DESCRIPTION
`IntoIterator` should be used to convert owned type into iterator type, but it was implemented for borrowed `&'a Board`.